### PR TITLE
remove projectRoutes path to stop app crashing

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,11 +1,9 @@
 const router = require('express').Router();
 
 const apiRoutes = require('./api');
-const projectRoutes = require('./projectRoutes.js');
 const homeRoutes = require('./homeRoutes.js');
 
 router.use('/', homeRoutes);
-router.use('/', projectRoutes);
 router.use('/', apiRoutes);
 
 module.exports = router;


### PR DESCRIPTION
had a random 'require projectRoutes' line in controllers folder, was making app crash bc it wasnt deleted along w/ projectRoutes